### PR TITLE
Feat: add more allowed file types

### DIFF
--- a/node_helper.js
+++ b/node_helper.js
@@ -8,7 +8,7 @@ const {
 module.exports = NodeHelper.create({
 	imgNameList: [], // Array<{ id: number; name: string }>
 	imgBase64: new Object(), // { base64: string; mimeType: string }
-	imgAuthorized: 'png|jpg|jpeg|gif',
+	imgAuthorized: 'png|PNG|jpg|JPG|jpeg|JPEG|gif|GIF|bmp|BMP|webp|WEBP|ico|ICO|dib|DIB',
 
 	init: function () {
 		console.log('MMM-FTP-image module helper initialized.');


### PR DESCRIPTION
I forgot to include this in the last PR. All of these file types were tested. svg file type does not work, so it is not included in the authorized image types. It might be good to add toLowerCase() method to change all file type names to lowercase instead of 'jpg|JPG....'