### PR TITLE
fix(error): implement reset event

### DIFF
--- a/MMM-FTP-image.js
+++ b/MMM-FTP-image.js
@@ -51,13 +51,24 @@ Module.register('MMM-FTP-image', {
 					this.scheduleImgUpdateInterval();
 					this.finishAllImgInCurrentDirectory = false;
 				}
-				break;
+
+				if (this.imageLoadFinished) break;
 
 			case 'FTP_IMG_BASE64':
 				this.logMessage('Images received !');
 				this.imgBase64 = payload;
 				this.incrementImageIndex();
 				this.updateDom();
+				break;
+
+			case 'RESET':
+				this.logMessage('RESET');
+				this.imageLoadFinished = false;
+				this.finishAllImgInCurrentDirectory = true;
+				this.imgNameList = [];
+				this.imageDisplayedNumber = 0;
+				clearInterval(this.intervalInstance);
+				this.getListImgNameFromFTPServer();
 				break;
 		}
 	},
@@ -149,6 +160,7 @@ Module.register('MMM-FTP-image', {
 
 	incrementImageIndex: function () {
 		this.logMessage(`Current image index: ${this.imageDisplayedNumber}`);
+		console.log('IMG list length', this.imgNameList.length, this.imageDisplayedNumber);
 
 		if (this.imageDisplayedNumber === this.imgNameList.length - 1) {
 			clearInterval(this.intervalInstance);

--- a/MMM-FTP-image.js
+++ b/MMM-FTP-image.js
@@ -160,7 +160,6 @@ Module.register('MMM-FTP-image', {
 
 	incrementImageIndex: function () {
 		this.logMessage(`Current image index: ${this.imageDisplayedNumber}`);
-		console.log('IMG list length', this.imgNameList.length, this.imageDisplayedNumber);
 
 		if (this.imageDisplayedNumber === this.imgNameList.length - 1) {
 			clearInterval(this.intervalInstance);


### PR DESCRIPTION
## Issues

See ➡️ #8 

## Description

Bug identified in the image search when changing directory. Sometimes, for an unknown reason (would deserve further investigation) the `ftp` package does not find the next file that must be loaded and therefore returns an error.

## Resolution 

For fix this bug, i implement `RESET` event. It is trigger when the package `ftp` return an error. 
The `RESET` event, trigger the reset of module and start again to index 0. 